### PR TITLE
Extension method for use Protobuf Object in Httptest response mock

### DIFF
--- a/src/Flurl.Http.Protobuf/FlurlHttpTestProtobufExtensions.cs
+++ b/src/Flurl.Http.Protobuf/FlurlHttpTestProtobufExtensions.cs
@@ -1,0 +1,46 @@
+﻿using Flurl.Http.Testing;
+using System.Net.Http;
+
+namespace Flurl.Http.Protobuf
+{
+
+    /// <summary>
+    /// A Extension for Flurl.Http.Testing.HttpTest to allows the protobuf fake test response.
+    /// </summary>
+    public static partial class FlurlHttpTestProtobufExtensions
+    {
+
+        /// <summary>
+        /// Summary:
+        ///     Adds an HttpResponseMessage to the response queue with the given data serialized
+        ///     to Profobuf as the content body.
+        ///     The Object body need to have a protobuf-net data notation do serialize the object.
+        ///
+        /// Parameters:
+        ///   body:
+        ///     The object to be Protobuf-serialized and used as the simulated response body.
+        ///
+        ///   status:
+        ///     The simulated HTTP status. Default is 200.
+        ///
+        ///   headers:
+        ///     The simulated response headers (optional).
+        ///
+        ///   cookies:
+        ///     The simulated response cookies (optional).
+        ///
+        ///   replaceUnderscoreWithHyphen:
+        ///     If true, underscores in property names of headers will be replaced by hyphens.
+        ///     Default is true.
+        ///
+        /// Returns:
+        ///     The current HttpTest object (so more responses can be chained).
+        /// </summary>
+        public static HttpTest RespondWithProtobuf<T>(this HttpTest test, T body, int status = 200, object headers = null, object cookies = null, bool replaceUnderscoreWithHyphen = true)
+        {
+            var protoBody = ProtoSerializer.Serialize(body);
+            var content = new ByteArrayContent(protoBody);
+            return test.RespondWith(content, status, headers, cookies, replaceUnderscoreWithHyphen);
+        }
+    }
+}

--- a/test/Flurl.Http.Protobuf.Tests/FlurlHttpTestProtobufTests.cs
+++ b/test/Flurl.Http.Protobuf.Tests/FlurlHttpTestProtobufTests.cs
@@ -1,0 +1,49 @@
+﻿using Flurl.Http.Protobuf.Tests.Models;
+using Flurl.Http.Testing;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Flurl.Http.Protobuf.Tests
+{
+    public class FlurlHttpTestProtobufTests
+    {
+
+        [Test]
+        public async Task RespondWithProtobuf_GetObject()
+        {
+            HttpTest test = new HttpTest();
+
+            ComplexObject objectToSerialize = new ComplexObject
+            {
+                Id = 1,
+                Name = "Test",
+                Address = new List<Address>
+                {
+                    new Address
+                    {
+                        Line1 = "Address line 1",
+                        Line2 = "Address line 2"
+                    }
+                }
+            };
+
+            test.RespondWithProtobuf(objectToSerialize);
+
+            var response = await FlurlRequest().PostProtobufAsync(new ComplexObject()).ReceiveProtobuf<ComplexObject>();
+
+            Assert.AreEqual(objectToSerialize.Id, response.Id);
+            Assert.AreEqual(objectToSerialize.Name, response.Name);
+            Assert.AreEqual(objectToSerialize.Address.Count, response.Address.Count);
+            Assert.AreEqual(objectToSerialize.Address[0].Line1, response.Address[0].Line1);
+            Assert.AreEqual(objectToSerialize.Address[0].Line2, response.Address[0].Line2);
+
+        }
+
+
+        private IFlurlRequest FlurlRequest()
+        {
+            return $"http://FakeTest".AllowAnyHttpStatus();
+        }
+    }
+}


### PR DESCRIPTION
For solve a test need, i've create a extension method for HttpTest Class to mock the response to allow's protobuf object.